### PR TITLE
PipeEvaluator keep reminding after training stops

### DIFF
--- a/elegantrl/run.py
+++ b/elegantrl/run.py
@@ -249,7 +249,8 @@ class PipeEvaluator:
         print(f'| UsedTime: {time.time() - evaluator.start_time:>7.0f} | SavedDir: {cwd}')
 
         while True:  # wait for the forced stop from main process
-            time.sleep(1943)
+            self.pipe0.recv()
+            self.pipe0.send((False, False))
 
 
 def process_safely_terminate(process):


### PR DESCRIPTION
PipeEvaluator will no longer respond to the pipeline when it finds the 'stop' file, which may cause thread deadlock. 
Change to continue to respond to the pipeline and keep informing that the training has been asked to stop.